### PR TITLE
alias publish support version-latest

### DIFF
--- a/docs/zh/command/alias.md
+++ b/docs/zh/command/alias.md
@@ -235,7 +235,8 @@ Options
   --description [string]              [Optional] Specify the alias description     
   --alias-name [string]            	  [Required] Specify the fc alias name                   
   --gversion [number]              	  [Optional] The grayscale version id  
-  --version-id [number]            	  [Required] The version Id               
+  --version-id [number]            	  [Optional] The version Id               
+  --version-latest [boolean]          [Optional] Binding the latest service version          
   --weight [number]                   [Optional] The weight for grayscale version 
 
 Global Options
@@ -255,6 +256,7 @@ Options Help
 Examples with Yaml
 
   $ s alias publish --alias-name aliasName --version-id 2                             
+  $ s alias publish --alias-name aliasName --version-latest                         
   $ s alias publish --description description --alias-name aliasName --version-id 2 --gversion 3 --weight 20                                                      
 
 Examples with CLI
@@ -271,7 +273,8 @@ Examples with CLI
 | description  | -        | 选填           | 选填          | 别名描述                                                     |
 | alias-name   | -        | 必填           | 必填          | 别名                                                         |
 | gversion     | -        | 选填           | 选填          | 灰度版本Id。灰度版本权重填写时必填|
-| version-id   | -        | 必填           | 必填          | 版本Id                                                       |
+| version-id   | -        | 选填           | 选填          | 版本Id。如果指定 version-id 和 version-latest，则会出现交互选择指定哪个版本 |
+| version-latest | -      | 选填           | 选填          | 绑定当前服务最新的版本，优先级低于 version-id |
 | weight       | -        | 选填           | 选填          | 灰度版本权重。灰度版本Id填写时必填 |
 | access       | a        | 选填           | 选填          | 本次请求使用的密钥，可以使用通过[config命令](https://github.com/Serverless-Devs/Serverless-Devs/tree/master/docs/zh/command/config.md#config-add-命令) 配置的密钥信息，以及[配置到环境变量的密钥信息](https://github.com/Serverless-Devs/Serverless-Devs/tree/master/docs/zh/command/config.md#通过环境变量配置密钥信息) |
 | debug        | -        | 选填           | 选填          | 打开`debug`模式，将会输出更多日志信息                        |
@@ -305,6 +308,12 @@ fc-deploy-test:
   createdTime:             2021-11-08T06:51:36Z
   lastModifiedTime:        2021-11-08T06:54:02Z
 ```
+
+### Publish 主版本获取逻辑
+
+- 指定 version-id：直接使用指定的 version-id
+- 未指定 version-id，但是指定了 version-latest：获取版本列表，取下标0的版本号（版本列表默认倒序，下标0就是最大的版本号）
+- 未指定 version-id 和 version-latest：获取版本列表，如果仅有一个版本直接使用此版本号；如果是多个版本，那么会产生交互让用户选择
 
 ## 权限与策略说明
 

--- a/docs/zh/command/logs.md
+++ b/docs/zh/command/logs.md
@@ -57,11 +57,11 @@ Examples with Yaml
 
   $ s logs -s 2021-06-07T02:54:00+08:00 -e 2021-06-07T02:54:59+08:00 
   $ s logs -s 2021-06-07T02:54:00+08:00 -e 2021-06-07T02:54:59+08:00 --search error
-  $ s logs -t                                                        
+  $ s logs --tail                                                        
 
 Examples with CLI
 
-  $ s cli fc logs --region cn-hangzhou --service-name serviceName --function-name functionName -t
+  $ s cli fc logs --region cn-hangzhou --service-name serviceName --function-name functionName --tail
 ```
 
 ### 参数解析

--- a/src/lib/help/alias.ts
+++ b/src/lib/help/alias.ts
@@ -126,6 +126,11 @@ export const ALIAS_PUBLISH = [
         type: String,
       },
       {
+        name: 'version-latest',
+        description: '[Optional] Binding the latest service version',
+        type: String,
+      },
+      {
         name: 'description',
         description: '[Optional] Specify the alias description',
         type: String,
@@ -148,6 +153,7 @@ export const ALIAS_PUBLISH = [
     header: 'Examples with Yaml',
     content: [
       '$ s alias publish --alias-name aliasName --version-id 2',
+      '$ s alias publish --alias-name aliasName --version-latest',
       '$ s alias publish --description description --alias-name aliasName --version-id 2 --gversion 3 --weight 20'],
   },
   {

--- a/src/lib/help/logs.ts
+++ b/src/lib/help/logs.ts
@@ -43,21 +43,20 @@ export const LOGS = [
         type: String,
       },
       {
-        name: 'end-time',
-        description: '[Optional] Query log end time (timestamp or time format，like 1611827290000 or 2021-11-11T11:11:12+00:00)',
-        alias: 'e',
-        type: String,
-      },
-      {
         name: 'start-time',
         description: '[Optional] Query log start time (timestamp or time format，like 1611827290000 or 2021-11-11T11:11:12+00:00)',
         alias: 's',
         type: String,
       },
       {
+        name: 'end-time',
+        description: '[Optional] Query log end time (timestamp or time format，like 1611827290000 or 2021-11-11T11:11:12+00:00)',
+        alias: 'e',
+        type: String,
+      },
+      {
         name: 'tail',
         description: '[Optional] Continuous log output mode',
-        alias: 's',
         type: Boolean,
       },
     ],
@@ -69,11 +68,11 @@ export const LOGS = [
     content: [
       '$ s logs -s 2021-06-07T02:54:00+08:00 -e 2021-06-07T02:54:59+08:00 ',
       '$ s logs -s 2021-06-07T02:54:00+08:00 -e 2021-06-07T02:54:59+08:00 --search error',
-      '$ s logs -t',
+      '$ s logs --tail',
     ],
   },
   {
     header: 'Examples with CLI',
-    content: ['$ s cli fc logs --region cn-hangzhou --service-name serviceName --function-name functionName -t'],
+    content: ['$ s cli fc logs --region cn-hangzhou --service-name serviceName --function-name functionName --tail'],
   },
 ];


### PR DESCRIPTION
alias publish 逻辑：
1. 指定 version-id，直接使用
2. 未指定 version-id，但是指定了 version-latest，则获取版本列表，取下标0的版本号（默认倒序，下标0就是最大的版本号）
3. 未指定 version-id 和 version-latest，获取版本列表，如果仅有一个版本直接使用，如果是多个版本，交互，让用户选择

https://github.com/devsapp/fc/issues/150

日志 help 错误：
https://github.com/Serverless-Devs/Serverless-Devs/issues/389