### PR TITLE
文档runtime支持补充nodejs16和dotnetcore3.1

### DIFF
--- a/docs/zh/yaml/function.md
+++ b/docs/zh/yaml/function.md
@@ -95,12 +95,13 @@ function:
 
 runtime目前支持
 
-`nodejs14`、`nodejs12`、`nodejs10`、`nodejs8`、`nodejs6`、`nodejs4.4`   
+`nodejs16`、`nodejs14`、`nodejs12`、`nodejs10`、`nodejs8`、`nodejs6`、`nodejs4.4`   
 `python3.9`、`python3`、`python2.7`   
 `java11`、`java8`   
 `go1`   
 `php7.2`   
 `dotnetcore2.1`   
+`dotnetcore3.1`
 `custom`、`custom-container`   
 
 当 runtime 为 custom-container 服务角色权限：


### PR DESCRIPTION
参考文档：https://help.aliyun.com/document_detail/154438.html